### PR TITLE
feat: add per-turn token tracking to ConversationTurn

### DIFF
--- a/src/ai_usage_log/models/schemas.py
+++ b/src/ai_usage_log/models/schemas.py
@@ -82,12 +82,25 @@ class DailySummaryResult(BaseModel):
 # --- Claude JSONL session models ---
 
 
+class TurnTokens(BaseModel):
+    """Token usage for a single conversation turn."""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.input_tokens + self.output_tokens + self.cache_read_tokens + self.cache_creation_tokens
+
+
 class ConversationTurn(BaseModel):
     """A single user→assistant conversation turn."""
     timestamp: str
     user_prompt: str
     tools_used: list[str]
     response_summary: str
+    tokens: TurnTokens | None = None
 
 
 class ClaudeSessionData(BaseModel):


### PR DESCRIPTION
## Summary

- Add `TurnTokens` model with `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens` + computed `total` property
- Attach `tokens: TurnTokens | None` to each `ConversationTurn` during JSONL parsing
- Multiple assistant entries within a single turn (tool-use loops) sum correctly
- Invariant: sum of per-turn tokens == session-level totals

Closes #2

## Motivation

Enables the agent to measure token cost of specific skill invocations (e.g., `/ai-usage-log`) by identifying turns where `tools_used` contains `mcp__ai-usage-log__*` and summing their `tokens.total`.

## Test plan

- [x] `test_single_turn_tokens` — basic token breakdown per turn
- [x] `test_multi_turn_tokens_independent` — each turn gets only its own tokens
- [x] `test_multiple_assistant_entries_per_turn` — tool-use loops sum correctly within one turn
- [x] `test_turn_tokens_sum_equals_session_total` — invariant: sum of per-turn tokens == session totals
- [x] All 71 tests pass (`poetry run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)