### PR TITLE
feat(lazy-load): slim cache_path pattern for large-response tools

### DIFF
--- a/src/ai_usage_log/models/schemas.py
+++ b/src/ai_usage_log/models/schemas.py
@@ -334,3 +334,16 @@ class ClaudeSessionList(BaseModel):
     """List of discovered Claude Code sessions."""
     sessions: list[ClaudeSessionInfo]
     count: int
+
+
+class SlimResponse(BaseModel):
+    """Slim response for large-data tools — full JSON saved to cache file.
+
+    Callers use jq to extract specific fields from the cache file on demand.
+    All large-response tools return this when cache_path is provided or auto-generated.
+    """
+    cached_at: str                    # path to the full JSON cache file
+    schema_paths: list[str]           # flat list of jq paths with size hints
+    context: SessionContext | None = None  # inline context metadata (for prepare_session)
+    error: str | None = None          # set if cache file write failed
+    message: str = "Full response cached. Use jq to extract specific fields."

--- a/src/ai_usage_log/skill_data/SKILL.md
+++ b/src/ai_usage_log/skill_data/SKILL.md
@@ -12,16 +12,30 @@ Cross-platform skill for documenting AI sessions, tracking learnings, and identi
 ### Standard Flow (3 MCP calls, 1 user interaction)
 
 ```
-Step 0  prepare_session(cwd)             → context, dirs, previous, stats, computed_stats, timeline
+Step 0  prepare_session(cwd, cache_path) → slim response + full JSON at cache_path
+        ↳ Use jq to read previous_session, stats, computed_stats, timeline from cache_path
 Step 1  (no MCP) Tier Selection          → pick Tier 1/2/3
 Step 2  (no MCP) Session Reflection      → 2-round recall + agent feedback (only user interaction)
-Step 3  get_daily_jsonl_stats(today)     → aggregate JSONL stats for all related sessions
+Step 3  get_daily_jsonl_stats(today, cache_path=...) → slim + full stats at cache_path
+        ↳ Use jq to extract token totals, tools histogram, per-session data
 Step 4  (no MCP) Generate markdown       → assemble content with JSONL stats in Key Stats
 Step 5  (no MCP) Show generated content  → display rendered markdown to user
 Step 6  save_session_bundle(content=...) → auto-save immediately after display (no confirmation)
         ↳ MUST: update_session if Session ID still shows "pending"
 Step 7  (no MCP) Show result summary     → saved path, quick stats, key takeaways
 ```
+
+#### Large-Response Tool Cache Pattern
+
+All 5 large-response tools support `cache_path`:
+- `prepare_session(cwd, cache_path=...)` — full PrepareSessionResult
+- `read_claude_session(session_id, cache_path=...)` — full ClaudeSessionData
+- `read_claude_sessions(session_ids, cache_path=...)` — full ClaudeSessionsBatchResult
+- `get_session_timeline(session_id, cache_path=...)` — full SessionTimeline
+- `get_daily_jsonl_stats(date, cache_path=...)` — full DailyAggregate
+
+If `cache_path` is omitted, auto-saves to `/tmp/ai-usage-log/<tool>-<timestamp>.json`.
+Always returns slim response. Always use `jq` to extract what you need.
 
 ### Tier Selection Cheat Sheet
 
@@ -78,17 +92,37 @@ export AI_USAGE_LOG_PATH=~/Documents/ai-usage
 
 ### Step 0: Prepare Session (1 MCP call)
 
-Call `prepare_session(cwd=<current_working_directory>)`.
+Call `prepare_session(cwd=<current_working_directory>, cache_path=<your_workspace>/session-cache.json)`.
 
-Returns JSON with:
-- `context`: `{user, host, terminal, cwd, project, project_root, date, time, year, month}`
-- `structure`: dirs/files created (idempotent)
-- `previous_session`: latest session content + todos (or null)
-- `stats`: current statistics.md content
-- `computed_stats`: aggregated stats from session filenames (total sessions, by-agent, by-month) or null
-- `current_session_timeline`: auto-detected timeline from current JSONL session with RFC3339 timestamps, user prompts, tools used, and files modified (or null if no active JSONL session)
+**All large-response tools now use a slim cache pattern.** Full JSON is written to `cache_path` (or auto-generated under `/tmp/ai-usage-log/` if omitted). The tool always returns a slim response — use `jq` to extract specific fields on demand.
 
-Store these values — they're reused throughout. **`current_session_timeline` is the primary source for Timeline timestamps** — use its entries instead of fabricating times.
+#### Slim response fields (always inline):
+- `cached_at`: path to the full JSON cache file
+- `schema_paths`: flat list of available jq paths with size hints
+- `context`: core metadata `{user, host, terminal, cwd, project, project_root, date, time, year, month}` — inline, always small
+- `message`: reminder to use jq
+
+#### Extracting data from the cache:
+
+```bash
+# Get context inline from slim response — no jq needed
+# context.date, context.user, context.project, context.cwd are always inline
+
+# Read previous session content
+jq -r '.previous_session.content' <cache_path>
+
+# Get stats file content
+jq -r '.stats.content' <cache_path>
+
+# Get computed stats summary
+jq '.computed_stats.total_sessions, .computed_stats.by_agent' <cache_path>
+
+# Get session timeline entries
+jq '.current_session_timeline.entries' <cache_path>
+```
+
+Store `cached_at` from the slim response — it's the path to use for all jq extractions.
+**`current_session_timeline` is the primary source for Timeline timestamps** — use its entries instead of fabricating times.
 
 If `previous_session` exists and has open todos, present to user:
 

--- a/src/ai_usage_log/tools/claude_session_tools.py
+++ b/src/ai_usage_log/tools/claude_session_tools.py
@@ -4,6 +4,7 @@ from mcp.server.fastmcp import FastMCP
 
 from ..context import get_context
 from ..models.schemas import ClaudeSessionsBatchResult
+from ..utils.cache import write_to_cache
 
 
 def register(mcp: FastMCP) -> None:
@@ -40,16 +41,41 @@ def register(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
     )
-    async def read_claude_session(session_id: str, project_path: str = "") -> str:
+    async def read_claude_session(session_id: str, project_path: str = "", cache_path: str = "") -> str:
         """Parse JSONL session and return structured data for summarization.
+
+        Always returns a slim response with full data cached to a file.
+        If cache_path is empty, data is auto-saved to /tmp/ai-usage-log/read_claude_session-<ts>.json.
 
         Args:
             session_id: The session UUID (filename without .jsonl extension).
             project_path: Absolute project path to narrow search. Empty to scan all projects.
+            cache_path: Path to write full JSON response. Auto-generated in /tmp if empty.
         """
         service = get_context().claude_sessions
         result = service.read_session(session_id=session_id, project_path=project_path)
-        return result.model_dump_json(indent=2)
+        return write_to_cache(
+            result,
+            tool_name="read_claude_session",
+            schema_paths=[
+                ".session_id (small — UUID)",
+                ".project_name (small — project name)",
+                ".git_branch (small — branch name)",
+                ".model (small — model ID)",
+                ".start_time (small — ISO timestamp)",
+                ".end_time (small — ISO timestamp)",
+                ".duration_minutes (small — float)",
+                ".conversation (large — list of turns with prompts, tools, tokens)",
+                ".total_tool_calls (small — count)",
+                ".input_tokens (small — count)",
+                ".output_tokens (small — count)",
+                ".tools_summary (medium — dict of tool name to call count)",
+                ".files_read (medium — list of file paths)",
+                ".files_written (medium — list of file paths)",
+                ".commands_run (medium — list of commands)",
+            ],
+            cache_path=cache_path,
+        )
 
     @mcp.tool(
         name="get_session_timeline",
@@ -62,7 +88,7 @@ def register(mcp: FastMCP) -> None:
         },
     )
     async def get_session_timeline(
-        session_id: str, project_path: str = ""
+        session_id: str, project_path: str = "", cache_path: str = ""
     ) -> str:
         """Extract a lightweight timeline from a JSONL session for use in session logs.
 
@@ -70,13 +96,30 @@ def register(mcp: FastMCP) -> None:
         the minimum needed for writing accurate session log timelines without
         fabricating timestamps.
 
+        Always returns a slim response with full data cached to a file.
+        If cache_path is empty, data is auto-saved to /tmp/ai-usage-log/get_session_timeline-<ts>.json.
+
         Args:
             session_id: The session UUID (filename without .jsonl extension).
             project_path: Absolute project path to narrow search. Empty to scan all projects.
+            cache_path: Path to write full JSON response. Auto-generated in /tmp if empty.
         """
         service = get_context().claude_sessions
         result = service.get_timeline(session_id=session_id, project_path=project_path)
-        return result.model_dump_json(indent=2)
+        return write_to_cache(
+            result,
+            tool_name="get_session_timeline",
+            schema_paths=[
+                ".session_id (small — UUID)",
+                ".project_name (small — project name)",
+                ".start_time (small — ISO timestamp)",
+                ".end_time (small — ISO timestamp)",
+                ".duration_minutes (small — float)",
+                ".entries (large — list of timeline entries with timestamps, tools, files)",
+                ".entries[0].timestamp (small — RFC3339 timestamp of first entry)",
+            ],
+            cache_path=cache_path,
+        )
 
     @mcp.tool(
         name="read_claude_sessions",
@@ -89,13 +132,17 @@ def register(mcp: FastMCP) -> None:
         },
     )
     async def read_claude_sessions(
-        session_ids: list[str], project_path: str = ""
+        session_ids: list[str], project_path: str = "", cache_path: str = ""
     ) -> str:
         """Batch-read multiple JSONL sessions and return trimmed summaries.
+
+        Always returns a slim response with full data cached to a file.
+        If cache_path is empty, data is auto-saved to /tmp/ai-usage-log/read_claude_sessions-<ts>.json.
 
         Args:
             session_ids: List of session UUIDs to read.
             project_path: Absolute project path to narrow search. Empty to scan all projects.
+            cache_path: Path to write full JSON response. Auto-generated in /tmp if empty.
         """
         service = get_context().claude_sessions
         summaries = []
@@ -104,4 +151,17 @@ def register(mcp: FastMCP) -> None:
             summaries.append(data.to_summary())
 
         result = ClaudeSessionsBatchResult(sessions=summaries, count=len(summaries))
-        return result.model_dump_json(indent=2)
+        return write_to_cache(
+            result,
+            tool_name="read_claude_sessions",
+            schema_paths=[
+                ".count (small — number of sessions)",
+                ".sessions (large — list of session summaries)",
+                ".sessions[0].session_id (small — UUID of first session)",
+                ".sessions[0].project_name (small — project of first session)",
+                ".sessions[0].duration_minutes (small — duration of first session)",
+                ".sessions[0].tools_summary (medium — tool call counts for first session)",
+                ".sessions[0].conversation (large — turns of first session)",
+            ],
+            cache_path=cache_path,
+        )

--- a/src/ai_usage_log/tools/jsonl_stats_tools.py
+++ b/src/ai_usage_log/tools/jsonl_stats_tools.py
@@ -3,6 +3,7 @@
 from mcp.server.fastmcp import FastMCP
 
 from ..context import get_context
+from ..utils.cache import write_to_cache
 
 
 def register(mcp: FastMCP) -> None:
@@ -47,20 +48,44 @@ def register(mcp: FastMCP) -> None:
         },
     )
     async def get_daily_jsonl_stats(
-        date: str, date_end: str = "", project_path: str = ""
+        date: str, date_end: str = "", project_path: str = "", cache_path: str = ""
     ) -> str:
         """Aggregate cached stats from JSONL sessions for a date or date range.
 
         Scans JSONL files, extracts+caches stats for matching sessions, and returns
         an aggregate with totals, tools histogram, model distribution, and per-session details.
 
+        Always returns a slim response with full data cached to a file.
+        If cache_path is empty, data is auto-saved to /tmp/ai-usage-log/get_daily_jsonl_stats-<ts>.json.
+
         Args:
             date: Start date YYYY-MM-DD.
             date_end: Optional end date YYYY-MM-DD (inclusive). Defaults to same as date.
             project_path: Absolute project path to filter. Empty for all projects.
+            cache_path: Path to write full JSON response. Auto-generated in /tmp if empty.
         """
         ctx = get_context()
         result = ctx.jsonl_stats.get_daily_stats(
             date=date, date_end=date_end, project_path=project_path
         )
-        return result.model_dump_json(indent=2)
+        return write_to_cache(
+            result,
+            tool_name="get_daily_jsonl_stats",
+            schema_paths=[
+                ".date_range (small — date or range string)",
+                ".total_sessions (small — count)",
+                ".total_duration_minutes (small — float)",
+                ".total_input_tokens (small — count)",
+                ".total_output_tokens (small — count)",
+                ".total_cache_creation_tokens (small — count)",
+                ".total_cache_read_tokens (small — count)",
+                ".total_tool_calls (small — count)",
+                ".tools_histogram (medium — dict of tool to call count)",
+                ".model_distribution (medium — dict of model to session count)",
+                ".projects (medium — list of project names)",
+                ".sessions (large — list of per-session stats)",
+                ".cached_count (small — sessions read from cache)",
+                ".parsed_count (small — sessions freshly parsed)",
+            ],
+            cache_path=cache_path,
+        )

--- a/src/ai_usage_log/tools/session_tools.py
+++ b/src/ai_usage_log/tools/session_tools.py
@@ -17,6 +17,7 @@ from ..config.settings import (
 )
 from ..context import get_context
 from ..models.schemas import PrepareSessionResult, SaveBundleResult, SessionContext
+from ..utils.cache import write_to_cache
 from ..utils.content import resolve_content
 
 
@@ -179,16 +180,21 @@ def register(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
     )
-    async def prepare_session(cwd: str = "", year: str = "", month: str = "") -> str:
+    async def prepare_session(cwd: str = "", year: str = "", month: str = "", cache_path: str = "") -> str:
         """Batch setup for a new session: context + init dirs + previous session + stats.
 
         Combines get_session_context + init_structure + get_previous_session + get_stats
         into a single call. All original tools remain available individually.
 
+        Always returns a slim response with full data cached to a file.
+        If cache_path is empty, data is auto-saved to /tmp/ai-usage-log/prepare_session-<ts>.json.
+        Use jq to extract specific fields from the cache file.
+
         Args:
             cwd: Current working directory (optional, defaults to server cwd).
             year: Four-digit year (optional, auto-detected if empty).
             month: Two-digit month (optional, auto-detected if empty).
+            cache_path: Path to write full JSON response. Auto-generated in /tmp if empty.
         """
         if not cwd:
             cwd = os.getcwd()
@@ -239,7 +245,29 @@ def register(mcp: FastMCP) -> None:
             computed_stats=computed_stats,
             current_session_timeline=current_timeline,
         )
-        return result.model_dump_json(indent=2)
+        return write_to_cache(
+            result,
+            tool_name="prepare_session",
+            schema_paths=[
+                ".context.date (small — today's date)",
+                ".context.user (small — username)",
+                ".context.project (small — detected project)",
+                ".context.cwd (small — working directory)",
+                ".context.year (small — year)",
+                ".context.month (small — month)",
+                ".structure.created_dirs (small — dirs created)",
+                ".previous_session.path (small — file path)",
+                ".previous_session.content (large — full session markdown)",
+                ".stats.content (large — full stats file text)",
+                ".stats.path (small — path to statistics.md)",
+                ".computed_stats.total_sessions (small — count)",
+                ".computed_stats.by_month (medium — monthly breakdown list)",
+                ".computed_stats.by_agent (medium — per-agent breakdown list)",
+                ".current_session_timeline (large — all conversation turns)",
+            ],
+            cache_path=cache_path,
+            context=context,
+        )
 
     @mcp.tool(
         name="save_session_bundle",

--- a/src/ai_usage_log/utils/cache.py
+++ b/src/ai_usage_log/utils/cache.py
@@ -1,0 +1,54 @@
+"""Helper for the slim cache_path pattern used by large-response tools."""
+
+import os
+import time
+from typing import Any
+
+from ..models.schemas import SessionContext, SlimResponse
+
+
+def write_to_cache(
+    result: Any,
+    tool_name: str,
+    schema_paths: list[str],
+    cache_path: str = "",
+    context: SessionContext | None = None,
+) -> str:
+    """Write result to cache file and return slim JSON response.
+
+    If cache_path is empty, auto-generates a path under /tmp/ai-usage-log/.
+    The full result JSON is written to the cache file; only slim metadata is returned.
+
+    Args:
+        result: Pydantic model to serialize.
+        tool_name: Tool name used in auto-generated filenames.
+        schema_paths: List of jq path hints describing the cached content.
+        cache_path: Explicit cache file path. Auto-generated if empty.
+        context: Optional SessionContext to include inline in slim response.
+
+    Returns:
+        Slim JSON string with cached_at, schema_paths, and optional context.
+    """
+    if not cache_path:
+        tmp_dir = "/tmp/ai-usage-log"
+        os.makedirs(tmp_dir, exist_ok=True)
+        cache_path = os.path.join(tmp_dir, f"{tool_name}-{int(time.time())}.json")
+    else:
+        parent = os.path.dirname(cache_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+
+    error = None
+    try:
+        with open(cache_path, "w") as f:
+            f.write(result.model_dump_json(indent=2))
+    except Exception as e:
+        error = str(e)
+
+    slim = SlimResponse(
+        cached_at=cache_path,
+        schema_paths=schema_paths,
+        context=context,
+        error=error,
+    )
+    return slim.model_dump_json(indent=2)


### PR DESCRIPTION
## Summary
- Add `SlimResponse` model to `schemas.py` with jq paths schema + inline context
- Add `utils/cache.py` with shared `write_to_cache()` helper
- Add `cache_path: str = ""` param to all 5 large-response tools: `prepare_session`, `read_claude_session`, `read_claude_sessions`, `get_session_timeline`, `get_daily_jsonl_stats`
- All tools now always return slim response — full JSON auto-cached to `cache_path` or `/tmp/ai-usage-log/<tool>-<ts>.json`
- Update `SKILL.md` with cache pattern docs and jq examples

## Test plan
- [x] 149 tests pass
- [x] Compile check clean
- [x] Manual test: explicit `cache_path` and auto-tmp fallback both work
- [x] Pre-commit hooks (ruff) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)